### PR TITLE
Update for Cypress renames

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,10 @@ const codes = {
 
 function keydownCommand ($el, key) {
   const message = `sending the "${key}" keydown event`
-  const log = Cypress.Log.command({
+  const log = Cypress.log({
     name: `keydown: ${key}`,
     message: message,
-    onConsole: function () {
+    consoleProps: function () {
       return {
         Subject: $el
       }
@@ -61,8 +61,8 @@ function keydownCommand ($el, key) {
   return $el
 }
 
-Cypress.addChildCommand('keydown', keydownCommand)
-Cypress.addChildCommand('left', $el => keydownCommand($el, 'ArrowLeft'))
-Cypress.addChildCommand('right', $el => keydownCommand($el, 'ArrowRight'))
-Cypress.addChildCommand('up', $el => keydownCommand($el, 'ArrowUp'))
-Cypress.addChildCommand('down', $el => keydownCommand($el, 'ArrowDown'))
+Cypress.Commands.add('keydown', { prevSubject: "dom" }, keydownCommand)
+Cypress.Commands.add('left', { prevSubject: "dom" }, $el => keydownCommand($el, 'ArrowLeft'))
+Cypress.Commands.add('right', { prevSubject: "dom" }, $el => keydownCommand($el, 'ArrowRight'))
+Cypress.Commands.add('up', { prevSubject: "dom" }, $el => keydownCommand($el, 'ArrowUp'))
+Cypress.Commands.add('down', { prevSubject: "dom" }, $el => keydownCommand($el, 'ArrowDown'))


### PR DESCRIPTION
It looks like this plugin hasn't been updated in years so I'm not sure if it still makes sense to use, but I have a situation where I need to be able to simulate pressing the arrow keys without all the extra stuff that `cy.type()` now does, including issuing a `click` if the subject isn't focused, etc.

The code looks pretty simple; I just attempted to bring it up to date since there were some renames early in Cypress development that affected the current code.